### PR TITLE
Set up snapshot testing for AST output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,324 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea5d730647d4fadd988536d06fecce94b7b4f2a7efdae548f1cf4b63205518ab"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "bstr"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2f7349907b712260e64b0afe2f84692af14a454be26187d9df565c7f69266a"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "console"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "globset"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759c97c1e17c55525b57192c06a267cda0ac5210b222d6b82189a2338fa1c13d"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "insta"
+version = "1.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa511b2e298cd49b1856746f6bb73e17036bcd66b25f5e92cdcdbec9bd75686"
+dependencies = [
+ "console",
+ "globset",
+ "lazy_static",
+ "linked-hash-map",
+ "similar",
+ "walkdir",
+ "yaml-rust",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "libc"
+version = "0.2.148"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "log"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "memchr"
+version = "2.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+
+[[package]]
 name = "new-nu-parser"
 version = "0.1.0"
+dependencies = [
+ "insta",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "regex"
+version = "1.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebee201405406dbf528b8b672104ae6d6d63e6d118cb10e4d51abbc7b58044ff"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b23e92ee4318893fa3fe3e6fb365258efbfe6ac6ab30f090cdcbb7aa37efa9"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.188"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.188"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "similar"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
+
+[[package]]
+name = "syn"
+version = "2.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "walkdir"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ edition = "2021"
 [lib]
 name = "new_nu_parser"
 path = "src/lib.rs"
+
+[dev-dependencies]
+insta = { version = "1.33.0", features = ["glob"] }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -67,6 +67,19 @@ impl Compiler {
         }
     }
 
+    pub fn display_state(&self) -> String {
+        self.ast_nodes
+            .iter()
+            .enumerate()
+            .map(|(idx, ast_node)| {
+                format!(
+                    "{}: {:?} ({} to {})\n",
+                    idx, ast_node, self.span_start[idx], self.span_end[idx]
+                )
+            })
+            .collect()
+    }
+
     pub fn add_file(&mut self, fname: &str, contents: &[u8]) {
         let span_offset = self.source.len();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
 pub mod compiler;
 pub mod errors;
 pub mod parser;
+#[cfg(test)]
+mod test;

--- a/src/snapshots/new_nu_parser__test__node_output@if_.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@if_.nu.snap
@@ -1,0 +1,19 @@
+---
+source: src/test.rs
+expression: "evaluate_example(path, &contents)"
+input_file: tests/if_.nu
+---
+0: Variable (4 to 5)
+1: Int (8 to 11)
+2: Let { variable_name: NodeId(0), ty: None, initializer: NodeId(1), is_mutable: false } (0 to 11)
+3: Variable (16 to 18)
+4: LessThan (19 to 20)
+5: Int (21 to 24)
+6: BinaryOp { lhs: NodeId(3), op: NodeId(4), rhs: NodeId(5) } (16 to 24)
+7: Int (31 to 32)
+8: Block(BlockId(0)) (25 to 34)
+9: Int (46 to 47)
+10: Block(BlockId(1)) (40 to 49)
+11: If { condition: NodeId(6), then_block: NodeId(8), else_expression: Some(NodeId(10)) } (13 to 49)
+12: Block(BlockId(2)) (0 to 0)
+

--- a/src/snapshots/new_nu_parser__test__node_output@let_.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@let_.nu.snap
@@ -1,0 +1,11 @@
+---
+source: src/test.rs
+expression: "evaluate_example(path, &contents)"
+input_file: tests/let_.nu
+---
+0: Variable (4 to 5)
+1: Int (8 to 11)
+2: Let { variable_name: NodeId(0), ty: None, initializer: NodeId(1), is_mutable: false } (0 to 11)
+3: Variable (13 to 15)
+4: Block(BlockId(0)) (0 to 0)
+

--- a/src/snapshots/new_nu_parser__test__node_output@list.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@list.nu.snap
@@ -1,0 +1,11 @@
+---
+source: src/test.rs
+expression: "evaluate_example(path, &contents)"
+input_file: tests/list.nu
+---
+0: Int (1 to 2)
+1: Int (4 to 5)
+2: Int (7 to 8)
+3: List([NodeId(0), NodeId(1), NodeId(2)]) (0 to 8)
+4: Block(BlockId(0)) (0 to 0)
+

--- a/src/snapshots/new_nu_parser__test__node_output@literals.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@literals.nu.snap
@@ -1,0 +1,13 @@
+---
+source: src/test.rs
+expression: "evaluate_example(path, &contents)"
+input_file: tests/literals.nu
+---
+0: True (1 to 5)
+1: Null (6 to 10)
+2: Int (11 to 12)
+3: Name (13 to 16)
+4: String (17 to 22)
+5: List([NodeId(0), NodeId(1), NodeId(2), NodeId(3), NodeId(4)]) (0 to 22)
+6: Block(BlockId(0)) (0 to 0)
+

--- a/src/snapshots/new_nu_parser__test__node_output@math.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@math.nu.snap
@@ -1,0 +1,11 @@
+---
+source: src/test.rs
+expression: "evaluate_example(path, &contents)"
+input_file: tests/math.nu
+---
+0: Int (0 to 1)
+1: Plus (2 to 3)
+2: Int (4 to 5)
+3: BinaryOp { lhs: NodeId(0), op: NodeId(1), rhs: NodeId(2) } (0 to 5)
+4: Block(BlockId(0)) (0 to 0)
+

--- a/src/snapshots/new_nu_parser__test__node_output@mut_.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@mut_.nu.snap
@@ -1,0 +1,19 @@
+---
+source: src/test.rs
+expression: "evaluate_example(path, &contents)"
+input_file: tests/mut_.nu
+---
+0: Variable (4 to 5)
+1: Name (7 to 10)
+2: Type { name: NodeId(1), params: None, optional: false } (7 to 10)
+3: Int (13 to 16)
+4: Let { variable_name: NodeId(0), ty: Some(NodeId(2)), initializer: NodeId(3), is_mutable: true } (0 to 16)
+5: Variable (18 to 20)
+6: Assignment (21 to 22)
+7: Int (23 to 24)
+8: Plus (25 to 26)
+9: Int (27 to 30)
+10: BinaryOp { lhs: NodeId(7), op: NodeId(8), rhs: NodeId(9) } (23 to 30)
+11: BinaryOp { lhs: NodeId(5), op: NodeId(6), rhs: NodeId(10) } (18 to 30)
+12: Block(BlockId(0)) (0 to 0)
+

--- a/src/snapshots/new_nu_parser__test__node_output@reparse.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@reparse.nu.snap
@@ -1,0 +1,18 @@
+---
+source: src/test.rs
+expression: "evaluate_example(path, &contents)"
+input_file: tests/reparse.nu
+---
+0: Name (0 to 3)
+1: Name (4 to 7)
+2: Name (9 to 10)
+3: Garbage (10 to 11)
+4: Name (12 to 18)
+5: List([NodeId(2), NodeId(3), NodeId(4)]) (8 to 18)
+6: Name (22 to 26)
+7: Variable (27 to 29)
+8: Block(BlockId(0)) (20 to 31)
+9: Name (33 to 36)
+10: Int (37 to 38)
+11: Block(BlockId(1)) (0 to 0)
+

--- a/src/snapshots/new_nu_parser__test__node_output@string.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@string.nu.snap
@@ -1,0 +1,8 @@
+---
+source: src/test.rs
+expression: "evaluate_example(path, &contents)"
+input_file: tests/string.nu
+---
+0: String (0 to 13)
+1: Block(BlockId(0)) (0 to 0)
+

--- a/src/snapshots/new_nu_parser__test__node_output@string_operation.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@string_operation.nu.snap
@@ -1,0 +1,11 @@
+---
+source: src/test.rs
+expression: "evaluate_example(path, &contents)"
+input_file: tests/string_operation.nu
+---
+0: String (0 to 5)
+1: Plus (6 to 7)
+2: String (8 to 13)
+3: BinaryOp { lhs: NodeId(0), op: NodeId(1), rhs: NodeId(2) } (0 to 13)
+4: Block(BlockId(0)) (0 to 0)
+

--- a/src/snapshots/new_nu_parser__test__node_output@table.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@table.nu.snap
@@ -1,0 +1,17 @@
+---
+source: src/test.rs
+expression: "evaluate_example(path, &contents)"
+input_file: tests/table.nu
+---
+0: String (7 to 10)
+1: String (12 to 15)
+2: List([NodeId(0), NodeId(1)]) (6 to 15)
+3: Int (24 to 25)
+4: Int (27 to 28)
+5: List([NodeId(3), NodeId(4)]) (23 to 28)
+6: Int (35 to 36)
+7: Int (38 to 39)
+8: List([NodeId(6), NodeId(7)]) (34 to 39)
+9: Table { header: NodeId(2), rows: [NodeId(5), NodeId(8)] } (0 to 41)
+10: Block(BlockId(0)) (0 to 0)
+

--- a/src/snapshots/new_nu_parser__test__node_output@table2.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@table2.nu.snap
@@ -1,0 +1,17 @@
+---
+source: src/test.rs
+expression: "evaluate_example(path, &contents)"
+input_file: tests/table2.nu
+---
+0: Name (7 to 8)
+1: Name (10 to 11)
+2: List([NodeId(0), NodeId(1)]) (6 to 11)
+3: Int (20 to 21)
+4: Int (23 to 24)
+5: List([NodeId(3), NodeId(4)]) (19 to 24)
+6: Int (31 to 32)
+7: Int (34 to 35)
+8: List([NodeId(6), NodeId(7)]) (30 to 35)
+9: Table { header: NodeId(2), rows: [NodeId(5), NodeId(8)] } (0 to 37)
+10: Block(BlockId(0)) (0 to 0)
+

--- a/src/test.rs
+++ b/src/test.rs
@@ -14,3 +14,10 @@ fn evaluate_example(fname: &Path) -> String {
 
     compiler.display_state()
 }
+
+#[test]
+fn test_node_output() {
+    insta::glob!("../tests", "*.nu", |path| {
+        insta::assert_snapshot!(evaluate_example(path));
+    });
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,0 +1,16 @@
+use std::path::Path;
+use crate::{compiler::Compiler, parser::Parser};
+
+fn evaluate_example(fname: &Path) -> String {
+    let mut compiler = Compiler::new();
+    let contents = std::fs::read(&fname).expect("We only run tests found by glob");
+
+    let span_offset = compiler.span_offset();
+    compiler.add_file(&fname.to_string_lossy(), &contents);
+
+    let parser = Parser::new(compiler, span_offset);
+
+    compiler = parser.parse();
+
+    compiler.display_state()
+}


### PR DESCRIPTION
We are still moving fast and breaking things, before we set up super stringent tests maybe let's validate the output of the parser for changes.

I simply took what `cargo run` would output for the different example files and made those the initial snapshots. Some of them still contain garbage. As soon as we fix those the snapshots can be updated.


- Add way to get AST output for tests
- Use `insta` and `cargo-insta` for snapshot testing
- Commit initial snapshots
