### PR TITLE
Fix tpo in `is_simple_expression`: `new` -> `null`

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1430,7 +1430,7 @@ impl Parser {
                 token_type: TokenType::Name,
                 span_start,
                 span_end,
-            }) if &self.compiler.source[span_start..span_end] == b"new" => true,
+            }) if &self.compiler.source[span_start..span_end] == b"null" => true,
             Some(Token {
                 token_type: TokenType::Name,
                 ..


### PR DESCRIPTION
We don't have a `new` keyword at the moment so that probably meant `null`
