### PR TITLE
Fix expected value for invalid range test

### DIFF
--- a/src/snapshots/new_nu_parser__test__node_output@invalid_range.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@invalid_range.nu.snap
@@ -6,5 +6,5 @@ input_file: tests/invalid_range.nu
 0: Int (0 to 1)
 1: Garbage (2 to 4)
 2: Int (5 to 6)
-3: Block(BlockId(0)) (0 to 0)
+3: Block(BlockId(0)) (0 to 7)
 


### PR DESCRIPTION
Running the tests failed with the following expected value. Seems like the block at the end is the top-level block which in the case of `invalid_range.nu` indeed contains 7 characters, so the new value seems correct to me.