### PR TITLE
Start toolkit.nu; Add span highlighting tool

### DIFF
--- a/toolkit.nu
+++ b/toolkit.nu
@@ -1,0 +1,12 @@
+# Prints input string with highlighted span
+#
+# Useful for debugging parser output
+export def span [span_start: int, span_end: int]: string -> nothing {
+    let s = $in | encode utf8
+
+    let pre = $s | bytes at ..$span_start | decode
+    let highlighted = $s | bytes at $span_start..$span_end | decode
+    let post = $s | bytes at $span_end.. | decode
+
+    print ($pre + $'(ansi ru)($highlighted)(ansi reset)' + $post)
+}


### PR DESCRIPTION
This starts `toolkit.nu` to collect helpful utilities.

The first utility I made is the `span` command which highlights the input string. For example,
```nushell
> open tests/if_.nu | span 16 24
```
will highlight and underline the `$x < 100` part.

The `span` command is helpful for debugging if you want to check the spans printed by running the parser.