### PR TITLE
Add a name binding pass for variables

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -42,16 +42,6 @@ pub struct Compiler {
     // pub call_resolution: HashMap<NodeId, CallTarget>,
     // pub type_resolution: HashMap<NodeId, TypeId>,
     pub errors: Vec<SourceError>,
-    // === The following are used for the resolution pass ===
-    // /// All scope frames ever entered, indexed by ScopeId
-    // pub scope: Vec<Frame>,
-    // /// Stack of currently entered scope frames
-    // pub scope_stack: Vec<ScopeId>,
-    //
-    // /// Variables, indexed by VarId
-    // pub variables: Vec<Variable>,
-    // /// Mapping of variable's name node -> Variable
-    // pub var_resolution: HashMap<NodeId, VarId>,
 }
 
 impl Default for Compiler {

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -290,7 +290,7 @@ impl Compiler {
                 let def_scope = self.exit_scope();
 
                 let AstNode::Block(block_id) = self.ast_nodes[block.0] else {
-                    panic!("internal error: closure's body is not a block");
+                    panic!("internal error: command definition's body is not a block");
                 };
 
                 self.resolve_block(block, block_id, Some(def_scope));
@@ -328,7 +328,7 @@ impl Compiler {
                 self.resolve_node(range);
 
                 let AstNode::Block(block_id) = self.ast_nodes[block.0] else {
-                    panic!("internal error: closure's body is not a block");
+                    panic!("internal error: for's body is not a block");
                 };
 
                 self.resolve_block(block, block_id, Some(for_body_scope));

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -250,10 +250,6 @@ impl Compiler {
         if !self.ast_nodes.is_empty() {
             let last = self.ast_nodes.len() - 1;
             let last_node_id = NodeId(last);
-
-            self.scope.push(Frame::new(FrameType::Scope, last_node_id));
-            self.scope_stack.push(ScopeId(0));
-
             self.resolve_node(last_node_id)
         }
     }
@@ -460,7 +456,6 @@ impl Compiler {
             .rposition(|scope_id| self.scope[scope_id.0].frame_type == FrameType::Scope)
         {
             None => panic!("internal error: no scope frame to exit"),
-            Some(0) => panic!("internal error: can't exit the top-most scope frame"),
             Some(pos) => {
                 let scope_id = self.scope_stack[pos];
                 self.scope_stack.truncate(pos);

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -132,26 +132,8 @@ impl Compiler {
     }
 
     pub fn print(&self) {
-        for (idx, ast_node) in self.ast_nodes.iter().enumerate() {
-            println!(
-                "{}: {:?} ({} to {})",
-                idx, ast_node, self.spans[idx].start, self.spans[idx].end
-            );
-        }
-        if !self.errors.is_empty() {
-            println!("==== ERRORS ====");
-            for error in &self.errors {
-                println!(
-                    "{:?} (NodeId {}): {}",
-                    error.severity, error.node_id.0, error.message
-                );
-            }
-        }
-
-        println!("==== SCOPE ====");
-        for (i, scope) in self.scope.iter().enumerate() {
-            println!("{i}: {scope:?}");
-        }
+        let output = self.display_state();
+        print!("{output}");
     }
 
     #[allow(clippy::format_collect)]
@@ -180,7 +162,21 @@ impl Compiler {
 
         result.push_str("==== SCOPE ====\n");
         for (i, scope) in self.scope.iter().enumerate() {
-            result.push_str(&format!("{i}: {scope:?}\n"));
+            let mut vars: Vec<String> = scope
+                .variables
+                .iter()
+                .map(|(name, id)| format!("{0}: {id:?}", String::from_utf8_lossy(name)))
+                .collect();
+
+            vars.sort();
+
+            let line = format!(
+                "{i}: Frame {0:?}, variables: [ {1} ], node_id: {2:?}\n",
+                scope.frame_type,
+                vars.join(", "),
+                scope.node_id
+            );
+            result.push_str(&line);
         }
 
         result

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -1,7 +1,11 @@
+use crate::errors::Severity;
 use crate::{
     errors::SourceError,
     parser::{AstNode, Block, NodeId},
 };
+use std::collections::HashMap;
+use std::env::var;
+use std::thread::scope;
 
 pub struct RollbackPoint {
     idx_span_start: usize,
@@ -11,11 +15,50 @@ pub struct RollbackPoint {
     span_offset: usize,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct Span {
     pub start: usize,
     pub end: usize,
 }
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub struct ScopeId(pub usize);
+
+#[derive(Debug, PartialEq)]
+pub enum ScopeType {
+    /// Default scope marking the scope of a block/closure
+    Scope,
+    /// Immutable scope brought in by an overlay
+    Overlay,
+    /// Mutable scope inserted after activating an overlay to prevent mutating the overlay frame
+    Light,
+}
+
+#[derive(Debug)]
+pub struct Scope {
+    pub scope_type: ScopeType,
+    pub variables: HashMap<Vec<u8>, NodeId>,
+    /// Node that defined the scope (e.g., a block or overlay)
+    pub node_id: NodeId,
+}
+
+impl Scope {
+    pub fn new(scope_type: ScopeType, node_id: NodeId) -> Self {
+        Scope {
+            scope_type,
+            variables: HashMap::new(),
+            node_id,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Variable {
+    pub is_mutable: bool,
+}
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub struct VarId(pub usize);
 
 #[derive(Debug)]
 pub struct Compiler {
@@ -33,8 +76,6 @@ pub struct Compiler {
     pub file_offsets: Vec<(String, usize, usize)>, // fname, start, end
 
     // Definitions:
-    // indexed by VarId
-    // pub variables: Vec<Variable>,
     // indexed by FunId
     // pub functions: Vec<Function>,
     // indexed by TypeId
@@ -42,9 +83,19 @@ pub struct Compiler {
 
     // Use/def
     // pub call_resolution: HashMap<NodeId, CallTarget>,
-    // pub var_resolution: HashMap<NodeId, VarId>,
     // pub type_resolution: HashMap<NodeId, TypeId>,
     pub errors: Vec<SourceError>,
+
+    // === The following are used for the resolution pass ===
+    /// All scopes ever entered, indexed by ScopeId
+    pub scopes: Vec<Scope>,
+    /// Stack of currently entered scopes
+    pub scope_stack: Vec<ScopeId>,
+
+    /// Variables, indexed by VarId
+    pub variables: Vec<Variable>,
+    /// Mapping of variable's name node -> Variable
+    pub var_resolution: HashMap<NodeId, VarId>,
 }
 
 impl Default for Compiler {
@@ -73,6 +124,12 @@ impl Compiler {
             // var_resolution: HashMap::new(),
             // type_resolution: HashMap::new(),
             errors: vec![],
+
+            scopes: vec![],
+            scope_stack: vec![],
+
+            variables: vec![],
+            var_resolution: HashMap::new(),
         }
     }
 
@@ -152,5 +209,136 @@ impl Compiler {
         self.spans.truncate(rbp.idx_span_start);
 
         rbp.span_offset
+    }
+
+    /// Get span of node
+    pub fn get_span(&self, node_id: NodeId) -> Span {
+        *self
+            .spans
+            .get(node_id.0)
+            .expect("internal error: missing span of node")
+    }
+
+    /// Get the source contents of a span of a node
+    pub fn get_span_contents(&self, node_id: NodeId) -> &[u8] {
+        let span = self.get_span(node_id);
+        self.source
+            .get(span.start..span.end)
+            .expect("internal error: missing source of span")
+    }
+
+    // === The following methods are used for the resolution pass ===
+
+    pub fn resolve(&mut self) {
+        if !self.ast_nodes.is_empty() {
+            let last = self.ast_nodes.len() - 1;
+            let last_node_id = NodeId(last);
+
+            self.scopes.push(Scope::new(ScopeType::Scope, last_node_id));
+            self.scope_stack.push(ScopeId(0));
+
+            self.resolve_node(last_node_id)
+        }
+    }
+
+    pub fn resolve_node(&mut self, node_id: NodeId) {
+        match self.ast_nodes[node_id.0] {
+            AstNode::Block(block_id) => {
+                // TODO: Remove clone
+                let block = self
+                    .blocks
+                    .get(block_id.0)
+                    .expect("internal error: missing block")
+                    .clone();
+
+                self.enter_scope(node_id);
+                for inner_node_id in block.nodes {
+                    self.resolve_node(inner_node_id);
+                }
+                self.exit_scope();
+            }
+            AstNode::Let {
+                variable_name,
+                ty,
+                initializer,
+                is_mutable,
+            } => {
+                self.resolve_node(initializer);
+                self.define_variable(variable_name, is_mutable)
+            }
+            AstNode::Variable => self.resolve_variable(node_id),
+            _ => (),
+        }
+    }
+
+    /// Enter a scope, e.g., a block or a closure
+    pub fn enter_scope(&mut self, node_id: NodeId) {
+        self.scopes.push(Scope::new(ScopeType::Scope, node_id));
+        self.scope_stack.push(ScopeId(self.scopes.len() - 1));
+    }
+
+    /// Exit a scope, e.g., when reaching the end of a block or a closure
+    ///
+    /// When exiting a scope, all overlays (and corresponding light scopes) are removed along
+    /// with the removed scope.
+    pub fn exit_scope(&mut self) {
+        match self
+            .scope_stack
+            .iter()
+            .rposition(|scope_id| self.scopes[scope_id.0].scope_type == ScopeType::Scope)
+        {
+            None => panic!("internal error: no scope frame to exit"),
+            Some(0) => panic!("internal error: can't exit the top-most scope frame"),
+            Some(pos) => self.scope_stack.truncate(pos),
+        }
+    }
+
+    pub fn define_variable(&mut self, var_name_id: NodeId, is_mutable: bool) {
+        let var_name = self.get_span_contents(var_name_id).to_vec();
+
+        let current_scope_id = self
+            .scope_stack
+            .last()
+            .expect("internal error: missing scope frame id");
+
+        self.scopes[current_scope_id.0]
+            .variables
+            .insert(var_name, var_name_id);
+
+        let var = Variable { is_mutable };
+        self.variables.push(var);
+        let var_id = VarId(self.variables.len() - 1);
+
+        // let the definition of a variable also count as its use
+        self.var_resolution.insert(var_name_id, var_id);
+    }
+
+    pub fn find_variable(&self, var_name: &[u8]) -> Option<NodeId> {
+        for scope_id in self.scope_stack.iter().rev() {
+            if let Some(id) = self.scopes[scope_id.0].variables.get(var_name) {
+                return Some(*id);
+            }
+        }
+
+        None
+    }
+
+    pub fn resolve_variable(&mut self, unbound_node_id: NodeId) {
+        let var_name = self.get_span_contents(unbound_node_id);
+
+        if let Some(node_id) = self.find_variable(var_name) {
+            let var_id = self
+                .var_resolution
+                .get(&node_id)
+                .expect("internal error: missing resolved variable");
+
+            self.var_resolution.insert(unbound_node_id, *var_id);
+        } else {
+            self.errors.push(SourceError {
+                message: "variable not found".to_string(),
+                node_id: unbound_node_id,
+                severity: Severity::Error,
+            })
+        }
     }
 }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -1,9 +1,7 @@
-use crate::errors::Severity;
 use crate::{
     errors::SourceError,
-    parser::{AstNode, Block, BlockId, NodeId},
+    parser::{AstNode, Block, NodeId},
 };
-use std::collections::HashMap;
 
 pub struct RollbackPoint {
     idx_span_start: usize,
@@ -19,50 +17,11 @@ pub struct Span {
     pub end: usize,
 }
 
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
-pub struct ScopeId(pub usize);
-
-#[derive(Debug, PartialEq)]
-pub enum FrameType {
-    /// Default scope frame marking the scope of a block/closure
-    Scope,
-    /// Immutable frame brought in by an overlay
-    Overlay,
-    /// Mutable frame inserted after activating an overlay to prevent mutating the overlay frame
-    Light,
-}
-
-#[derive(Debug)]
-pub struct Frame {
-    pub frame_type: FrameType,
-    pub variables: HashMap<Vec<u8>, NodeId>,
-    /// Node that defined the scope frame (e.g., a block or overlay)
-    pub node_id: NodeId,
-}
-
-impl Frame {
-    pub fn new(scope_type: FrameType, node_id: NodeId) -> Self {
-        Frame {
-            frame_type: scope_type,
-            variables: HashMap::new(),
-            node_id,
-        }
-    }
-}
-
-#[derive(Debug)]
-pub struct Variable {
-    pub is_mutable: bool,
-}
-
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
-pub struct VarId(pub usize);
-
 #[derive(Debug)]
 pub struct Compiler {
     // Core information, indexed by NodeId
     pub spans: Vec<Span>,
-    ast_nodes: Vec<AstNode>,
+    pub ast_nodes: Vec<AstNode>,
     // node_types: Vec<TypeId>,
     // node_lifetimes: Vec<AllocationLifetime>,
 
@@ -83,17 +42,16 @@ pub struct Compiler {
     // pub call_resolution: HashMap<NodeId, CallTarget>,
     // pub type_resolution: HashMap<NodeId, TypeId>,
     pub errors: Vec<SourceError>,
-
     // === The following are used for the resolution pass ===
-    /// All scope frames ever entered, indexed by ScopeId
-    pub scope: Vec<Frame>,
-    /// Stack of currently entered scope frames
-    pub scope_stack: Vec<ScopeId>,
-
-    /// Variables, indexed by VarId
-    pub variables: Vec<Variable>,
-    /// Mapping of variable's name node -> Variable
-    pub var_resolution: HashMap<NodeId, VarId>,
+    // /// All scope frames ever entered, indexed by ScopeId
+    // pub scope: Vec<Frame>,
+    // /// Stack of currently entered scope frames
+    // pub scope_stack: Vec<ScopeId>,
+    //
+    // /// Variables, indexed by VarId
+    // pub variables: Vec<Variable>,
+    // /// Mapping of variable's name node -> Variable
+    // pub var_resolution: HashMap<NodeId, VarId>,
 }
 
 impl Default for Compiler {
@@ -122,12 +80,6 @@ impl Compiler {
             // var_resolution: HashMap::new(),
             // type_resolution: HashMap::new(),
             errors: vec![],
-
-            scope: vec![],
-            scope_stack: vec![],
-
-            variables: vec![],
-            var_resolution: HashMap::new(),
         }
     }
 
@@ -138,45 +90,23 @@ impl Compiler {
 
     #[allow(clippy::format_collect)]
     pub fn display_state(&self) -> String {
-        let mut result: String = self
-            .ast_nodes
-            .iter()
-            .enumerate()
-            .map(|(idx, ast_node)| {
-                format!(
-                    "{}: {:?} ({} to {})\n",
-                    idx, ast_node, self.spans[idx].start, self.spans[idx].end
-                )
-            })
-            .collect();
+        let mut result = "==== COMPILER ====\n".to_string();
+
+        for (idx, ast_node) in self.ast_nodes.iter().enumerate() {
+            result.push_str(&format!(
+                "{}: {:?} ({} to {})\n",
+                idx, ast_node, self.spans[idx].start, self.spans[idx].end
+            ));
+        }
 
         if !self.errors.is_empty() {
-            result.push_str("==== ERRORS ====\n");
+            result.push_str("==== COMPILER ERRORS ====\n");
             for error in &self.errors {
                 result.push_str(&format!(
                     "{:?} (NodeId {}): {}\n",
                     error.severity, error.node_id.0, error.message
                 ));
             }
-        }
-
-        result.push_str("==== SCOPE ====\n");
-        for (i, scope) in self.scope.iter().enumerate() {
-            let mut vars: Vec<String> = scope
-                .variables
-                .iter()
-                .map(|(name, id)| format!("{0}: {id:?}", String::from_utf8_lossy(name)))
-                .collect();
-
-            vars.sort();
-
-            let line = format!(
-                "{i}: Frame {0:?}, variables: [ {1} ], node_id: {2:?}\n",
-                scope.frame_type,
-                vars.join(", "),
-                scope.node_id
-            );
-            result.push_str(&line);
         }
 
         result
@@ -242,286 +172,5 @@ impl Compiler {
         self.source
             .get(span.start..span.end)
             .expect("internal error: missing source of span")
-    }
-
-    // === The following methods are used for the name binding pass ===
-
-    pub fn resolve(&mut self) {
-        if !self.ast_nodes.is_empty() {
-            let last = self.ast_nodes.len() - 1;
-            let last_node_id = NodeId(last);
-            self.resolve_node(last_node_id)
-        }
-    }
-
-    pub fn resolve_node(&mut self, node_id: NodeId) {
-        match self.ast_nodes[node_id.0] {
-            AstNode::Variable => self.resolve_variable(node_id),
-            AstNode::Block(block_id) => self.resolve_block(node_id, block_id, None),
-            AstNode::Closure { params, block } => {
-                // making sure the closure parameters and body end up in the same scope frame
-                let closure_scope = if let Some(params) = params {
-                    self.enter_scope(block);
-                    self.resolve_node(params);
-                    Some(self.exit_scope())
-                } else {
-                    None
-                };
-
-                let AstNode::Block(block_id) = self.ast_nodes[block.0] else {
-                    panic!("internal error: closure's body is not a block");
-                };
-
-                self.resolve_block(block, block_id, closure_scope);
-            }
-            AstNode::Def {
-                name: _,
-                params,
-                return_ty: _,
-                block,
-            } => {
-                // making sure the def parameters and body end up in the same scope frame
-                self.enter_scope(block);
-                self.resolve_node(params);
-                let def_scope = self.exit_scope();
-
-                let AstNode::Block(block_id) = self.ast_nodes[block.0] else {
-                    panic!("internal error: command definition's body is not a block");
-                };
-
-                self.resolve_block(block, block_id, Some(def_scope));
-            }
-            AstNode::Params(ref params) => {
-                // TODO: Remove clone
-                let params = params.clone();
-                for param in params {
-                    self.define_variable(param, false);
-                }
-            }
-            AstNode::Let {
-                variable_name,
-                ty: _,
-                initializer,
-                is_mutable,
-            } => {
-                self.resolve_node(initializer);
-                self.define_variable(variable_name, is_mutable)
-            }
-            AstNode::While { condition, block } => {
-                self.resolve_node(condition);
-                self.resolve_node(block);
-            }
-            AstNode::For {
-                variable,
-                range,
-                block,
-            } => {
-                // making sure the for loop variable and body end up in the same scope frame
-                self.enter_scope(block);
-                self.define_variable(variable, false);
-                let for_body_scope = self.exit_scope();
-
-                self.resolve_node(range);
-
-                let AstNode::Block(block_id) = self.ast_nodes[block.0] else {
-                    panic!("internal error: for's body is not a block");
-                };
-
-                self.resolve_block(block, block_id, Some(for_body_scope));
-            }
-            AstNode::Loop { block } => {
-                self.resolve_node(block);
-            }
-            AstNode::Call { head: _, ref args } => {
-                // TODO: Remove clone
-                let args = args.clone();
-                for arg in args {
-                    self.resolve_node(arg);
-                }
-            }
-            AstNode::BinaryOp { lhs, op: _, rhs } => {
-                self.resolve_node(lhs);
-                self.resolve_node(rhs);
-            }
-            AstNode::Range { lhs, rhs } => {
-                self.resolve_node(lhs);
-                self.resolve_node(rhs);
-            }
-            AstNode::List(ref nodes) => {
-                // TODO: Remove clone
-                let nodes = nodes.clone();
-                for node in nodes {
-                    self.resolve_node(node);
-                }
-            }
-            AstNode::Table { header, ref rows } => {
-                // TODO: Remove clone
-                let rows = rows.clone();
-                self.resolve_node(header);
-                for row in rows {
-                    self.resolve_node(row);
-                }
-            }
-            AstNode::Record { ref pairs } => {
-                // TODO: Remove clone
-                let pairs = pairs.clone();
-                for (key, val) in pairs {
-                    self.resolve_node(key);
-                    self.resolve_node(val);
-                }
-            }
-            AstNode::MemberAccess { target, field } => {
-                self.resolve_node(target);
-                self.resolve_node(field);
-            }
-            AstNode::MethodCall { target: _, call } => {
-                self.resolve_node(call);
-            }
-            AstNode::If {
-                condition,
-                then_block,
-                else_block,
-            } => {
-                self.resolve_node(condition);
-                self.resolve_node(then_block);
-                if let Some(block) = else_block {
-                    self.resolve_node(block);
-                }
-            }
-            AstNode::Match {
-                target,
-                ref match_arms,
-            } => {
-                // TODO: Remove clone
-                let match_arms = match_arms.clone();
-                self.resolve_node(target);
-                for (arm_lhs, arm_rhs) in match_arms {
-                    self.resolve_node(arm_lhs);
-                    self.resolve_node(arm_rhs);
-                }
-            }
-            AstNode::Statement(node) => self.resolve_node(node),
-            AstNode::Param { .. } => (/* seems unused for now */),
-            AstNode::Type { .. } => ( /* probably doesn't make sense to resolve? */ ),
-            AstNode::NamedValue { .. } => (/* seems unused for now */),
-            // All remaining matches do not contain NodeId => there is nothing to resolve
-            _ => (),
-        }
-    }
-
-    pub fn resolve_block(
-        &mut self,
-        node_id: NodeId,
-        block_id: BlockId,
-        reused_scope: Option<ScopeId>,
-    ) {
-        // TODO: Remove clone
-        let block = self
-            .blocks
-            .get(block_id.0)
-            .expect("internal error: missing block")
-            .clone();
-
-        if let Some(scope_id) = reused_scope {
-            self.enter_existing_scope(scope_id);
-        } else {
-            self.enter_scope(node_id);
-        }
-
-        for inner_node_id in block.nodes {
-            self.resolve_node(inner_node_id);
-        }
-        self.exit_scope();
-    }
-
-    /// Enter an existing scope frame, e.g., a block or a closure
-    pub fn enter_existing_scope(&mut self, scope_id: ScopeId) {
-        self.scope_stack.push(scope_id);
-    }
-
-    /// Enter a new scope frame, e.g., a block or a closure
-    pub fn enter_scope(&mut self, node_id: NodeId) {
-        self.scope.push(Frame::new(FrameType::Scope, node_id));
-        self.scope_stack.push(ScopeId(self.scope.len() - 1));
-    }
-
-    /// Exit a scope frame, e.g., when reaching the end of a block or a closure
-    ///
-    /// When exiting a scope frame, all overlays (and corresponding light frames) are removed along
-    /// with the removed frame.
-    pub fn exit_scope(&mut self) -> ScopeId {
-        match self
-            .scope_stack
-            .iter()
-            .rposition(|scope_id| self.scope[scope_id.0].frame_type == FrameType::Scope)
-        {
-            None => panic!("internal error: no scope frame to exit"),
-            Some(pos) => {
-                let scope_id = self.scope_stack[pos];
-                self.scope_stack.truncate(pos);
-                scope_id
-            }
-        }
-    }
-
-    pub fn define_variable(&mut self, var_name_id: NodeId, is_mutable: bool) {
-        let var_name = self.get_span_contents(var_name_id);
-        let var_name = trim_var_name(var_name).to_vec();
-
-        let current_scope_id = self
-            .scope_stack
-            .last()
-            .expect("internal error: missing scope frame id");
-
-        self.scope[current_scope_id.0]
-            .variables
-            .insert(var_name, var_name_id);
-
-        let var = Variable { is_mutable };
-        self.variables.push(var);
-        let var_id = VarId(self.variables.len() - 1);
-
-        // let the definition of a variable also count as its use
-        self.var_resolution.insert(var_name_id, var_id);
-    }
-
-    pub fn find_variable(&self, var_name: &[u8]) -> Option<NodeId> {
-        for scope_id in self.scope_stack.iter().rev() {
-            if let Some(id) = self.scope[scope_id.0]
-                .variables
-                .get(trim_var_name(var_name))
-            {
-                return Some(*id);
-            }
-        }
-
-        None
-    }
-
-    pub fn resolve_variable(&mut self, unbound_node_id: NodeId) {
-        let var_name = self.get_span_contents(unbound_node_id);
-
-        if let Some(node_id) = self.find_variable(var_name) {
-            let var_id = self
-                .var_resolution
-                .get(&node_id)
-                .expect("internal error: missing resolved variable");
-
-            self.var_resolution.insert(unbound_node_id, *var_id);
-        } else {
-            self.errors.push(SourceError {
-                message: "variable not found".to_string(),
-                node_id: unbound_node_id,
-                severity: Severity::Error,
-            })
-        }
-    }
-}
-
-fn trim_var_name(name: &[u8]) -> &[u8] {
-    if name.starts_with(b"$") && name.len() > 1 {
-        &name[1..]
-    } else {
-        name
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod compiler;
 pub mod errors;
 pub mod parser;
+pub mod resolver;
 #[cfg(test)]
 mod test;

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,15 +20,17 @@ fn main() {
 
         let parser = Parser::new(compiler, span_offset);
         compiler = parser.parse();
+
+        compiler.print();
+
+        if !compiler.errors.is_empty() {
+            exit(1);
+        }
+
+        let mut resolver = Resolver::new(&compiler);
+        resolver.resolve();
+        resolver.print();
+
+        compiler.merge_name_bindings(resolver.to_name_bindings());
     }
-
-    compiler.print();
-
-    if !compiler.errors.is_empty() {
-        exit(1);
-    }
-
-    let mut resolver = Resolver::new(&compiler);
-    resolver.resolve();
-    resolver.print();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use std::process::exit;
 
 use new_nu_parser::compiler::Compiler;
 use new_nu_parser::parser::Parser;
+use new_nu_parser::resolver::Resolver;
 
 fn main() {
     let mut compiler = Compiler::new();
@@ -18,10 +19,16 @@ fn main() {
         compiler.add_file(&fname, &contents);
 
         let parser = Parser::new(compiler, span_offset);
-
         compiler = parser.parse();
-        compiler.resolve();
     }
 
     compiler.print();
+
+    if !compiler.errors.is_empty() {
+        exit(1);
+    }
+
+    let mut resolver = Resolver::new(&compiler);
+    resolver.resolve();
+    resolver.print();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ fn main() {
         let parser = Parser::new(compiler, span_offset);
 
         compiler = parser.parse();
+        compiler.resolve();
     }
 
     compiler.print();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -151,10 +151,6 @@ pub enum AstNode {
         target: NodeId,
         field: NodeId,
     },
-    MethodCall {
-        target: NodeId,
-        call: NodeId,
-    },
     Block(BlockId),
     If {
         condition: NodeId,
@@ -480,20 +476,8 @@ impl Parser {
                             span_end,
                         );
                     }
-                    // TODO: Are we going to support method calls with dot syntax?
-                    AstNode::Call { args, .. } => {
-                        args.insert(0, expr);
-                        expr = self.create_node(
-                            AstNode::MethodCall {
-                                target: expr,
-                                call: field_or_call,
-                            },
-                            span_start,
-                            span_end,
-                        )
-                    }
                     _ => {
-                        self.error("expected field or method call");
+                        self.error("expected field");
                     }
                 }
             } else {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -480,6 +480,7 @@ impl Parser {
                             span_end,
                         );
                     }
+                    // TODO: Are we going to support method calls with dot syntax?
                     AstNode::Call { args, .. } => {
                         args.insert(0, expr);
                         expr = self.create_node(

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -44,6 +44,36 @@ pub struct Variable {
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub struct VarId(pub usize);
 
+pub struct NameBindings {
+    /// All scope frames ever entered, indexed by ScopeId
+    pub scope: Vec<Frame>,
+    /// Stack of currently entered scope frames
+    pub scope_stack: Vec<ScopeId>,
+    /// Variables, indexed by VarId
+    pub variables: Vec<Variable>,
+    /// Mapping of variable's name node -> Variable
+    pub var_resolution: HashMap<NodeId, VarId>,
+    pub errors: Vec<SourceError>,
+}
+
+impl NameBindings {
+    pub fn new() -> Self {
+        Self {
+            scope: vec![],
+            scope_stack: vec![],
+            variables: vec![],
+            var_resolution: HashMap::new(),
+            errors: vec![],
+        }
+    }
+}
+
+impl Default for NameBindings {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(Debug)]
 pub struct Resolver<'a> {
     // Immutable reference to a compiler after the first parsing pass
@@ -53,12 +83,11 @@ pub struct Resolver<'a> {
     pub scope: Vec<Frame>,
     /// Stack of currently entered scope frames
     pub scope_stack: Vec<ScopeId>,
-
     /// Variables, indexed by VarId
     pub variables: Vec<Variable>,
     /// Mapping of variable's name node -> Variable
     pub var_resolution: HashMap<NodeId, VarId>,
-
+    /// Errors encountered during name binding
     pub errors: Vec<SourceError>,
 }
 
@@ -68,11 +97,19 @@ impl<'a> Resolver<'a> {
             compiler,
             scope: vec![],
             scope_stack: vec![],
-
             variables: vec![],
             var_resolution: HashMap::new(),
-
             errors: vec![],
+        }
+    }
+
+    pub fn to_name_bindings(self) -> NameBindings {
+        NameBindings {
+            scope: self.scope,
+            scope_stack: self.scope_stack,
+            variables: self.variables,
+            var_resolution: self.var_resolution,
+            errors: self.errors,
         }
     }
 

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -235,9 +235,6 @@ impl<'a> Resolver<'a> {
                 self.resolve_node(target);
                 self.resolve_node(field);
             }
-            AstNode::MethodCall { target: _, call } => {
-                self.resolve_node(call);
-            }
             AstNode::If {
                 condition,
                 then_block,

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -1,0 +1,385 @@
+use crate::{
+    compiler::Compiler,
+    errors::{Severity, SourceError},
+    parser::{AstNode, BlockId, NodeId},
+};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub struct ScopeId(pub usize);
+
+#[derive(Debug, PartialEq)]
+pub enum FrameType {
+    /// Default scope frame marking the scope of a block/closure
+    Scope,
+    /// Immutable frame brought in by an overlay
+    Overlay,
+    /// Mutable frame inserted after activating an overlay to prevent mutating the overlay frame
+    Light,
+}
+
+#[derive(Debug)]
+pub struct Frame {
+    pub frame_type: FrameType,
+    pub variables: HashMap<Vec<u8>, NodeId>,
+    /// Node that defined the scope frame (e.g., a block or overlay)
+    pub node_id: NodeId,
+}
+
+impl Frame {
+    pub fn new(scope_type: FrameType, node_id: NodeId) -> Self {
+        Frame {
+            frame_type: scope_type,
+            variables: HashMap::new(),
+            node_id,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Variable {
+    pub is_mutable: bool,
+}
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub struct VarId(pub usize);
+
+#[derive(Debug)]
+pub struct Resolver<'a> {
+    // Immutable reference to a compiler after the first parsing pass
+    compiler: &'a Compiler,
+
+    /// All scope frames ever entered, indexed by ScopeId
+    pub scope: Vec<Frame>,
+    /// Stack of currently entered scope frames
+    pub scope_stack: Vec<ScopeId>,
+
+    /// Variables, indexed by VarId
+    pub variables: Vec<Variable>,
+    /// Mapping of variable's name node -> Variable
+    pub var_resolution: HashMap<NodeId, VarId>,
+
+    pub errors: Vec<SourceError>,
+}
+
+impl<'a> Resolver<'a> {
+    pub fn new(compiler: &'a Compiler) -> Self {
+        Self {
+            compiler,
+            scope: vec![],
+            scope_stack: vec![],
+
+            variables: vec![],
+            var_resolution: HashMap::new(),
+
+            errors: vec![],
+        }
+    }
+
+    pub fn print(&self) {
+        let output = self.display_state();
+        print!("{output}");
+    }
+
+    #[allow(clippy::format_collect)]
+    pub fn display_state(&self) -> String {
+        let mut result = String::new();
+
+        result.push_str("==== SCOPE ====\n");
+        for (i, scope) in self.scope.iter().enumerate() {
+            let mut vars: Vec<String> = scope
+                .variables
+                .iter()
+                .map(|(name, id)| format!("{0}: {id:?}", String::from_utf8_lossy(name)))
+                .collect();
+
+            vars.sort();
+
+            let line = format!(
+                "{i}: Frame {0:?}, variables: [ {1} ], node_id: {2:?}\n",
+                scope.frame_type,
+                vars.join(", "),
+                scope.node_id
+            );
+            result.push_str(&line);
+        }
+
+        if !self.errors.is_empty() {
+            result.push_str("==== SCOPE ERRORS ====\n");
+            for error in &self.errors {
+                result.push_str(&format!(
+                    "{:?} (NodeId {}): {}\n",
+                    error.severity, error.node_id.0, error.message
+                ));
+            }
+        }
+
+        result
+    }
+
+    pub fn resolve(&mut self) {
+        if !self.compiler.ast_nodes.is_empty() {
+            let last = self.compiler.ast_nodes.len() - 1;
+            let last_node_id = NodeId(last);
+            self.resolve_node(last_node_id)
+        }
+    }
+
+    pub fn resolve_node(&mut self, node_id: NodeId) {
+        match self.compiler.ast_nodes[node_id.0] {
+            AstNode::Variable => self.resolve_variable(node_id),
+            AstNode::Block(block_id) => self.resolve_block(node_id, block_id, None),
+            AstNode::Closure { params, block } => {
+                // making sure the closure parameters and body end up in the same scope frame
+                let closure_scope = if let Some(params) = params {
+                    self.enter_scope(block);
+                    self.resolve_node(params);
+                    Some(self.exit_scope())
+                } else {
+                    None
+                };
+
+                let AstNode::Block(block_id) = self.compiler.ast_nodes[block.0] else {
+                    panic!("internal error: closure's body is not a block");
+                };
+
+                self.resolve_block(block, block_id, closure_scope);
+            }
+            AstNode::Def {
+                name: _,
+                params,
+                return_ty: _,
+                block,
+            } => {
+                // making sure the def parameters and body end up in the same scope frame
+                self.enter_scope(block);
+                self.resolve_node(params);
+                let def_scope = self.exit_scope();
+
+                let AstNode::Block(block_id) = self.compiler.ast_nodes[block.0] else {
+                    panic!("internal error: command definition's body is not a block");
+                };
+
+                self.resolve_block(block, block_id, Some(def_scope));
+            }
+            AstNode::Params(ref params) => {
+                for param in params {
+                    self.define_variable(*param, false);
+                }
+            }
+            AstNode::Let {
+                variable_name,
+                ty: _,
+                initializer,
+                is_mutable,
+            } => {
+                self.resolve_node(initializer);
+                self.define_variable(variable_name, is_mutable)
+            }
+            AstNode::While { condition, block } => {
+                self.resolve_node(condition);
+                self.resolve_node(block);
+            }
+            AstNode::For {
+                variable,
+                range,
+                block,
+            } => {
+                // making sure the for loop variable and body end up in the same scope frame
+                self.enter_scope(block);
+                self.define_variable(variable, false);
+                let for_body_scope = self.exit_scope();
+
+                self.resolve_node(range);
+
+                let AstNode::Block(block_id) = self.compiler.ast_nodes[block.0] else {
+                    panic!("internal error: for's body is not a block");
+                };
+
+                self.resolve_block(block, block_id, Some(for_body_scope));
+            }
+            AstNode::Loop { block } => {
+                self.resolve_node(block);
+            }
+            AstNode::Call { head: _, ref args } => {
+                for arg in args {
+                    self.resolve_node(*arg);
+                }
+            }
+            AstNode::BinaryOp { lhs, op: _, rhs } => {
+                self.resolve_node(lhs);
+                self.resolve_node(rhs);
+            }
+            AstNode::Range { lhs, rhs } => {
+                self.resolve_node(lhs);
+                self.resolve_node(rhs);
+            }
+            AstNode::List(ref nodes) => {
+                for node in nodes {
+                    self.resolve_node(*node);
+                }
+            }
+            AstNode::Table { header, ref rows } => {
+                self.resolve_node(header);
+                for row in rows {
+                    self.resolve_node(*row);
+                }
+            }
+            AstNode::Record { ref pairs } => {
+                for (key, val) in pairs {
+                    self.resolve_node(*key);
+                    self.resolve_node(*val);
+                }
+            }
+            AstNode::MemberAccess { target, field } => {
+                self.resolve_node(target);
+                self.resolve_node(field);
+            }
+            AstNode::MethodCall { target: _, call } => {
+                self.resolve_node(call);
+            }
+            AstNode::If {
+                condition,
+                then_block,
+                else_block,
+            } => {
+                self.resolve_node(condition);
+                self.resolve_node(then_block);
+                if let Some(block) = else_block {
+                    self.resolve_node(block);
+                }
+            }
+            AstNode::Match {
+                target,
+                ref match_arms,
+            } => {
+                self.resolve_node(target);
+                for (arm_lhs, arm_rhs) in match_arms {
+                    self.resolve_node(*arm_lhs);
+                    self.resolve_node(*arm_rhs);
+                }
+            }
+            AstNode::Statement(node) => self.resolve_node(node),
+            AstNode::Param { .. } => (/* seems unused for now */),
+            AstNode::Type { .. } => ( /* probably doesn't make sense to resolve? */ ),
+            AstNode::NamedValue { .. } => (/* seems unused for now */),
+            // All remaining matches do not contain NodeId => there is nothing to resolve
+            _ => (),
+        }
+    }
+
+    pub fn resolve_block(
+        &mut self,
+        node_id: NodeId,
+        block_id: BlockId,
+        reused_scope: Option<ScopeId>,
+    ) {
+        let block = self
+            .compiler
+            .blocks
+            .get(block_id.0)
+            .expect("internal error: missing block");
+
+        if let Some(scope_id) = reused_scope {
+            self.enter_existing_scope(scope_id);
+        } else {
+            self.enter_scope(node_id);
+        }
+
+        for inner_node_id in &block.nodes {
+            self.resolve_node(*inner_node_id);
+        }
+        self.exit_scope();
+    }
+
+    /// Enter an existing scope frame, e.g., a block or a closure
+    pub fn enter_existing_scope(&mut self, scope_id: ScopeId) {
+        self.scope_stack.push(scope_id);
+    }
+
+    /// Enter a new scope frame, e.g., a block or a closure
+    pub fn enter_scope(&mut self, node_id: NodeId) {
+        self.scope.push(Frame::new(FrameType::Scope, node_id));
+        self.scope_stack.push(ScopeId(self.scope.len() - 1));
+    }
+
+    /// Exit a scope frame, e.g., when reaching the end of a block or a closure
+    ///
+    /// When exiting a scope frame, all overlays (and corresponding light frames) are removed along
+    /// with the removed frame.
+    pub fn exit_scope(&mut self) -> ScopeId {
+        match self
+            .scope_stack
+            .iter()
+            .rposition(|scope_id| self.scope[scope_id.0].frame_type == FrameType::Scope)
+        {
+            None => panic!("internal error: no scope frame to exit"),
+            Some(pos) => {
+                let scope_id = self.scope_stack[pos];
+                self.scope_stack.truncate(pos);
+                scope_id
+            }
+        }
+    }
+
+    pub fn define_variable(&mut self, var_name_id: NodeId, is_mutable: bool) {
+        let var_name = self.compiler.get_span_contents(var_name_id);
+        let var_name = trim_var_name(var_name).to_vec();
+
+        let current_scope_id = self
+            .scope_stack
+            .last()
+            .expect("internal error: missing scope frame id");
+
+        self.scope[current_scope_id.0]
+            .variables
+            .insert(var_name, var_name_id);
+
+        let var = Variable { is_mutable };
+        self.variables.push(var);
+        let var_id = VarId(self.variables.len() - 1);
+
+        // let the definition of a variable also count as its use
+        self.var_resolution.insert(var_name_id, var_id);
+    }
+
+    pub fn find_variable(&self, var_name: &[u8]) -> Option<NodeId> {
+        for scope_id in self.scope_stack.iter().rev() {
+            if let Some(id) = self.scope[scope_id.0]
+                .variables
+                .get(trim_var_name(var_name))
+            {
+                return Some(*id);
+            }
+        }
+
+        None
+    }
+
+    pub fn resolve_variable(&mut self, unbound_node_id: NodeId) {
+        let var_name = self.compiler.get_span_contents(unbound_node_id);
+
+        if let Some(node_id) = self.find_variable(var_name) {
+            let var_id = self
+                .var_resolution
+                .get(&node_id)
+                .expect("internal error: missing resolved variable");
+
+            self.var_resolution.insert(unbound_node_id, *var_id);
+        } else {
+            self.errors.push(SourceError {
+                message: "variable not found".to_string(),
+                node_id: unbound_node_id,
+                severity: Severity::Error,
+            })
+        }
+    }
+}
+
+fn trim_var_name(name: &[u8]) -> &[u8] {
+    if name.starts_with(b"$") && name.len() > 1 {
+        &name[1..]
+    } else {
+        name
+    }
+}

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -266,7 +266,7 @@ impl<'a> Resolver<'a> {
     }
 
     pub fn resolve_variable(&mut self, unbound_node_id: NodeId) {
-        let var_name = self.compiler.get_span_contents(unbound_node_id);
+        let var_name = trim_var_name(self.compiler.get_span_contents(unbound_node_id));
 
         if let Some(node_id) = self.find_variable(var_name) {
             let var_id = self
@@ -361,10 +361,7 @@ impl<'a> Resolver<'a> {
 
     pub fn find_variable(&self, var_name: &[u8]) -> Option<NodeId> {
         for scope_id in self.scope_stack.iter().rev() {
-            if let Some(id) = self.scope[scope_id.0]
-                .variables
-                .get(trim_var_name(var_name))
-            {
+            if let Some(id) = self.scope[scope_id.0].variables.get(var_name) {
                 return Some(*id);
             }
         }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -268,6 +268,25 @@ impl<'a> Resolver<'a> {
         }
     }
 
+    pub fn resolve_variable(&mut self, unbound_node_id: NodeId) {
+        let var_name = self.compiler.get_span_contents(unbound_node_id);
+
+        if let Some(node_id) = self.find_variable(var_name) {
+            let var_id = self
+                .var_resolution
+                .get(&node_id)
+                .expect("internal error: missing resolved variable");
+
+            self.var_resolution.insert(unbound_node_id, *var_id);
+        } else {
+            self.errors.push(SourceError {
+                message: "variable not found".to_string(),
+                node_id: unbound_node_id,
+                severity: Severity::Error,
+            })
+        }
+    }
+
     pub fn resolve_block(
         &mut self,
         node_id: NodeId,
@@ -354,25 +373,6 @@ impl<'a> Resolver<'a> {
         }
 
         None
-    }
-
-    pub fn resolve_variable(&mut self, unbound_node_id: NodeId) {
-        let var_name = self.compiler.get_span_contents(unbound_node_id);
-
-        if let Some(node_id) = self.find_variable(var_name) {
-            let var_id = self
-                .var_resolution
-                .get(&node_id)
-                .expect("internal error: missing resolved variable");
-
-            self.var_resolution.insert(unbound_node_id, *var_id);
-        } else {
-            self.errors.push(SourceError {
-                message: "variable not found".to_string(),
-                node_id: unbound_node_id,
-                severity: Severity::Error,
-            })
-        }
     }
 }
 

--- a/src/snapshots/new_nu_parser__test__node_output@closure.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@closure.nu.snap
@@ -3,6 +3,7 @@ source: src/test.rs
 expression: evaluate_example(path)
 input_file: tests/closure.nu
 ---
+==== COMPILER ====
 0: Name (3 to 4)
 1: Name (6 to 7)
 2: Params([NodeId(0), NodeId(1)]) (2 to 8)
@@ -14,9 +15,9 @@ input_file: tests/closure.nu
 8: Closure { params: Some(NodeId(2)), block: NodeId(7) } (0 to 17)
 9: Variable (18 to 20)
 10: Block(BlockId(1)) (0 to 42)
-==== ERRORS ====
-Error (NodeId 9): variable not found
 ==== SCOPE ====
 0: Frame Scope, variables: [  ], node_id: NodeId(10)
 1: Frame Scope, variables: [ a: NodeId(0), b: NodeId(1) ], node_id: NodeId(7)
+==== SCOPE ERRORS ====
+Error (NodeId 9): variable not found
 

--- a/src/snapshots/new_nu_parser__test__node_output@closure.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@closure.nu.snap
@@ -18,6 +18,5 @@ input_file: tests/closure.nu
 Error (NodeId 9): variable not found
 ==== SCOPE ====
 0: Frame Scope, variables: [  ], node_id: NodeId(10)
-1: Frame Scope, variables: [  ], node_id: NodeId(10)
-2: Frame Scope, variables: [ a: NodeId(0), b: NodeId(1) ], node_id: NodeId(7)
+1: Frame Scope, variables: [ a: NodeId(0), b: NodeId(1) ], node_id: NodeId(7)
 

--- a/src/snapshots/new_nu_parser__test__node_output@closure.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@closure.nu.snap
@@ -17,7 +17,7 @@ input_file: tests/closure.nu
 ==== ERRORS ====
 Error (NodeId 9): variable not found
 ==== SCOPE ====
-0: Frame { frame_type: Scope, variables: {}, node_id: NodeId(10) }
-1: Frame { frame_type: Scope, variables: {}, node_id: NodeId(10) }
-2: Frame { frame_type: Scope, variables: {[97]: NodeId(0), [98]: NodeId(1)}, node_id: NodeId(7) }
+0: Frame Scope, variables: [  ], node_id: NodeId(10)
+1: Frame Scope, variables: [  ], node_id: NodeId(10)
+2: Frame Scope, variables: [ a: NodeId(0), b: NodeId(1) ], node_id: NodeId(7)
 

--- a/src/snapshots/new_nu_parser__test__node_output@closure.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@closure.nu.snap
@@ -12,5 +12,12 @@ input_file: tests/closure.nu
 6: BinaryOp { lhs: NodeId(3), op: NodeId(4), rhs: NodeId(5) } (9 to 16)
 7: Block(BlockId(0)) (9 to 16)
 8: Closure { params: Some(NodeId(2)), block: NodeId(7) } (0 to 17)
-9: Block(BlockId(1)) (0 to 18)
+9: Variable (18 to 20)
+10: Block(BlockId(1)) (0 to 42)
+==== ERRORS ====
+Error (NodeId 9): variable not found
+==== SCOPE ====
+0: Frame { frame_type: Scope, variables: {}, node_id: NodeId(10) }
+1: Frame { frame_type: Scope, variables: {}, node_id: NodeId(10) }
+2: Frame { frame_type: Scope, variables: {[97]: NodeId(0), [98]: NodeId(1)}, node_id: NodeId(7) }
 

--- a/src/snapshots/new_nu_parser__test__node_output@closure2.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@closure2.nu.snap
@@ -10,4 +10,8 @@ input_file: tests/closure2.nu
 4: Block(BlockId(0)) (4 to 12)
 5: Closure { params: None, block: NodeId(4) } (0 to 13)
 6: Block(BlockId(1)) (0 to 14)
+==== SCOPE ====
+0: Frame Scope, variables: [  ], node_id: NodeId(6)
+1: Frame Scope, variables: [  ], node_id: NodeId(6)
+2: Frame Scope, variables: [  ], node_id: NodeId(4)
 

--- a/src/snapshots/new_nu_parser__test__node_output@closure2.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@closure2.nu.snap
@@ -15,6 +15,5 @@ Error (NodeId 0): variable not found
 Error (NodeId 2): variable not found
 ==== SCOPE ====
 0: Frame Scope, variables: [  ], node_id: NodeId(6)
-1: Frame Scope, variables: [  ], node_id: NodeId(6)
-2: Frame Scope, variables: [  ], node_id: NodeId(4)
+1: Frame Scope, variables: [  ], node_id: NodeId(4)
 

--- a/src/snapshots/new_nu_parser__test__node_output@closure2.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@closure2.nu.snap
@@ -3,6 +3,7 @@ source: src/test.rs
 expression: evaluate_example(path)
 input_file: tests/closure2.nu
 ---
+==== COMPILER ====
 0: Variable (4 to 6)
 1: Plus (7 to 8)
 2: Variable (9 to 11)
@@ -10,10 +11,10 @@ input_file: tests/closure2.nu
 4: Block(BlockId(0)) (4 to 12)
 5: Closure { params: None, block: NodeId(4) } (0 to 13)
 6: Block(BlockId(1)) (0 to 14)
-==== ERRORS ====
-Error (NodeId 0): variable not found
-Error (NodeId 2): variable not found
 ==== SCOPE ====
 0: Frame Scope, variables: [  ], node_id: NodeId(6)
 1: Frame Scope, variables: [  ], node_id: NodeId(4)
+==== SCOPE ERRORS ====
+Error (NodeId 0): variable not found
+Error (NodeId 2): variable not found
 

--- a/src/snapshots/new_nu_parser__test__node_output@closure2.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@closure2.nu.snap
@@ -10,6 +10,9 @@ input_file: tests/closure2.nu
 4: Block(BlockId(0)) (4 to 12)
 5: Closure { params: None, block: NodeId(4) } (0 to 13)
 6: Block(BlockId(1)) (0 to 14)
+==== ERRORS ====
+Error (NodeId 0): variable not found
+Error (NodeId 2): variable not found
 ==== SCOPE ====
 0: Frame Scope, variables: [  ], node_id: NodeId(6)
 1: Frame Scope, variables: [  ], node_id: NodeId(6)

--- a/src/snapshots/new_nu_parser__test__node_output@for.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@for.nu.snap
@@ -3,6 +3,7 @@ source: src/test.rs
 expression: evaluate_example(path)
 input_file: tests/for.nu
 ---
+==== COMPILER ====
 0: Variable (4 to 5)
 1: Int (8 to 9)
 2: Let { variable_name: NodeId(0), ty: None, initializer: NodeId(1), is_mutable: true } (0 to 9)

--- a/src/snapshots/new_nu_parser__test__node_output@for.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@for.nu.snap
@@ -35,4 +35,7 @@ input_file: tests/for.nu
 29: Block(BlockId(1)) (67 to 87)
 30: For { variable: NodeId(17), range: NodeId(21), block: NodeId(29) } (49 to 87)
 31: Block(BlockId(2)) (0 to 87)
+==== SCOPE ====
+0: Frame Scope, variables: [  ], node_id: NodeId(31)
+1: Frame Scope, variables: [ x: NodeId(0) ], node_id: NodeId(31)
 

--- a/src/snapshots/new_nu_parser__test__node_output@for.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@for.nu.snap
@@ -36,8 +36,7 @@ input_file: tests/for.nu
 30: For { variable: NodeId(17), range: NodeId(21), block: NodeId(29) } (49 to 87)
 31: Block(BlockId(2)) (0 to 87)
 ==== SCOPE ====
-0: Frame Scope, variables: [  ], node_id: NodeId(31)
-1: Frame Scope, variables: [ x: NodeId(0) ], node_id: NodeId(31)
-2: Frame Scope, variables: [ i: NodeId(3) ], node_id: NodeId(15)
-3: Frame Scope, variables: [ i: NodeId(17) ], node_id: NodeId(29)
+0: Frame Scope, variables: [ x: NodeId(0) ], node_id: NodeId(31)
+1: Frame Scope, variables: [ i: NodeId(3) ], node_id: NodeId(15)
+2: Frame Scope, variables: [ i: NodeId(17) ], node_id: NodeId(29)
 

--- a/src/snapshots/new_nu_parser__test__node_output@for.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@for.nu.snap
@@ -38,4 +38,6 @@ input_file: tests/for.nu
 ==== SCOPE ====
 0: Frame Scope, variables: [  ], node_id: NodeId(31)
 1: Frame Scope, variables: [ x: NodeId(0) ], node_id: NodeId(31)
+2: Frame Scope, variables: [ i: NodeId(3) ], node_id: NodeId(15)
+3: Frame Scope, variables: [ i: NodeId(17) ], node_id: NodeId(29)
 

--- a/src/snapshots/new_nu_parser__test__node_output@for_break_continue.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@for_break_continue.nu.snap
@@ -35,4 +35,7 @@ input_file: tests/for_break_continue.nu
 29: Block(BlockId(2)) (27 to 124)
 30: For { variable: NodeId(3), range: NodeId(7), block: NodeId(29) } (10 to 124)
 31: Block(BlockId(3)) (0 to 124)
+==== SCOPE ====
+0: Frame Scope, variables: [  ], node_id: NodeId(31)
+1: Frame Scope, variables: [ x: NodeId(0) ], node_id: NodeId(31)
 

--- a/src/snapshots/new_nu_parser__test__node_output@for_break_continue.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@for_break_continue.nu.snap
@@ -36,9 +36,8 @@ input_file: tests/for_break_continue.nu
 30: For { variable: NodeId(3), range: NodeId(7), block: NodeId(29) } (10 to 124)
 31: Block(BlockId(3)) (0 to 124)
 ==== SCOPE ====
-0: Frame Scope, variables: [  ], node_id: NodeId(31)
-1: Frame Scope, variables: [ x: NodeId(0) ], node_id: NodeId(31)
-2: Frame Scope, variables: [ i: NodeId(3) ], node_id: NodeId(29)
-3: Frame Scope, variables: [  ], node_id: NodeId(13)
-4: Frame Scope, variables: [  ], node_id: NodeId(20)
+0: Frame Scope, variables: [ x: NodeId(0) ], node_id: NodeId(31)
+1: Frame Scope, variables: [ i: NodeId(3) ], node_id: NodeId(29)
+2: Frame Scope, variables: [  ], node_id: NodeId(13)
+3: Frame Scope, variables: [  ], node_id: NodeId(20)
 

--- a/src/snapshots/new_nu_parser__test__node_output@for_break_continue.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@for_break_continue.nu.snap
@@ -38,4 +38,7 @@ input_file: tests/for_break_continue.nu
 ==== SCOPE ====
 0: Frame Scope, variables: [  ], node_id: NodeId(31)
 1: Frame Scope, variables: [ x: NodeId(0) ], node_id: NodeId(31)
+2: Frame Scope, variables: [ i: NodeId(3) ], node_id: NodeId(29)
+3: Frame Scope, variables: [  ], node_id: NodeId(13)
+4: Frame Scope, variables: [  ], node_id: NodeId(20)
 

--- a/src/snapshots/new_nu_parser__test__node_output@for_break_continue.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@for_break_continue.nu.snap
@@ -3,6 +3,7 @@ source: src/test.rs
 expression: evaluate_example(path)
 input_file: tests/for_break_continue.nu
 ---
+==== COMPILER ====
 0: Variable (4 to 5)
 1: Int (8 to 9)
 2: Let { variable_name: NodeId(0), ty: None, initializer: NodeId(1), is_mutable: true } (0 to 9)

--- a/src/snapshots/new_nu_parser__test__node_output@if_.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@if_.nu.snap
@@ -23,4 +23,7 @@ input_file: tests/if_.nu
 17: If { condition: NodeId(12), then_block: NodeId(14), else_block: Some(NodeId(16)) } (40 to 76)
 18: If { condition: NodeId(6), then_block: NodeId(8), else_block: Some(NodeId(17)) } (13 to 76)
 19: Block(BlockId(3)) (0 to 77)
+==== SCOPE ====
+0: Frame Scope, variables: [  ], node_id: NodeId(19)
+1: Frame Scope, variables: [ x: NodeId(0) ], node_id: NodeId(19)
 

--- a/src/snapshots/new_nu_parser__test__node_output@if_.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@if_.nu.snap
@@ -3,6 +3,7 @@ source: src/test.rs
 expression: evaluate_example(path)
 input_file: tests/if_.nu
 ---
+==== COMPILER ====
 0: Variable (4 to 5)
 1: Int (8 to 11)
 2: Let { variable_name: NodeId(0), ty: None, initializer: NodeId(1), is_mutable: false } (0 to 11)

--- a/src/snapshots/new_nu_parser__test__node_output@if_.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@if_.nu.snap
@@ -24,9 +24,8 @@ input_file: tests/if_.nu
 18: If { condition: NodeId(6), then_block: NodeId(8), else_block: Some(NodeId(17)) } (13 to 76)
 19: Block(BlockId(3)) (0 to 77)
 ==== SCOPE ====
-0: Frame Scope, variables: [  ], node_id: NodeId(19)
-1: Frame Scope, variables: [ x: NodeId(0) ], node_id: NodeId(19)
-2: Frame Scope, variables: [  ], node_id: NodeId(8)
-3: Frame Scope, variables: [  ], node_id: NodeId(14)
-4: Frame Scope, variables: [  ], node_id: NodeId(16)
+0: Frame Scope, variables: [ x: NodeId(0) ], node_id: NodeId(19)
+1: Frame Scope, variables: [  ], node_id: NodeId(8)
+2: Frame Scope, variables: [  ], node_id: NodeId(14)
+3: Frame Scope, variables: [  ], node_id: NodeId(16)
 

--- a/src/snapshots/new_nu_parser__test__node_output@if_.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@if_.nu.snap
@@ -26,4 +26,7 @@ input_file: tests/if_.nu
 ==== SCOPE ====
 0: Frame Scope, variables: [  ], node_id: NodeId(19)
 1: Frame Scope, variables: [ x: NodeId(0) ], node_id: NodeId(19)
+2: Frame Scope, variables: [  ], node_id: NodeId(8)
+3: Frame Scope, variables: [  ], node_id: NodeId(14)
+4: Frame Scope, variables: [  ], node_id: NodeId(16)
 

--- a/src/snapshots/new_nu_parser__test__node_output@invalid_range.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@invalid_range.nu.snap
@@ -7,4 +7,9 @@ input_file: tests/invalid_range.nu
 1: Garbage (2 to 4)
 2: Int (5 to 6)
 3: Block(BlockId(0)) (0 to 7)
+==== ERRORS ====
+Error (NodeId 1): incomplete expression
+==== SCOPE ====
+0: Frame Scope, variables: [  ], node_id: NodeId(3)
+1: Frame Scope, variables: [  ], node_id: NodeId(3)
 

--- a/src/snapshots/new_nu_parser__test__node_output@invalid_range.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@invalid_range.nu.snap
@@ -11,5 +11,4 @@ input_file: tests/invalid_range.nu
 Error (NodeId 1): incomplete expression
 ==== SCOPE ====
 0: Frame Scope, variables: [  ], node_id: NodeId(3)
-1: Frame Scope, variables: [  ], node_id: NodeId(3)
 

--- a/src/snapshots/new_nu_parser__test__node_output@invalid_range.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@invalid_range.nu.snap
@@ -3,12 +3,11 @@ source: src/test.rs
 expression: evaluate_example(path)
 input_file: tests/invalid_range.nu
 ---
+==== COMPILER ====
 0: Int (0 to 1)
 1: Garbage (2 to 4)
 2: Int (5 to 6)
 3: Block(BlockId(0)) (0 to 7)
-==== ERRORS ====
+==== COMPILER ERRORS ====
 Error (NodeId 1): incomplete expression
-==== SCOPE ====
-0: Frame Scope, variables: [  ], node_id: NodeId(3)
 

--- a/src/snapshots/new_nu_parser__test__node_output@invalid_record.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@invalid_record.nu.snap
@@ -3,6 +3,7 @@ source: src/test.rs
 expression: evaluate_example(path)
 input_file: tests/invalid_record.nu
 ---
+==== COMPILER ====
 0: Name (2 to 3)
 1: Int (5 to 6)
 2: Name (9 to 10)
@@ -10,9 +11,7 @@ input_file: tests/invalid_record.nu
 4: Garbage (13 to 13)
 5: Record { pairs: [(NodeId(0), NodeId(1)), (NodeId(2), NodeId(4))] } (0 to 0)
 6: Block(BlockId(0)) (0 to 13)
-==== ERRORS ====
+==== COMPILER ERRORS ====
 Error (NodeId 3): expected: colon ':'
 Error (NodeId 4): incomplete expression
-==== SCOPE ====
-0: Frame Scope, variables: [  ], node_id: NodeId(6)
 

--- a/src/snapshots/new_nu_parser__test__node_output@invalid_record.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@invalid_record.nu.snap
@@ -15,5 +15,4 @@ Error (NodeId 3): expected: colon ':'
 Error (NodeId 4): incomplete expression
 ==== SCOPE ====
 0: Frame Scope, variables: [  ], node_id: NodeId(6)
-1: Frame Scope, variables: [  ], node_id: NodeId(6)
 

--- a/src/snapshots/new_nu_parser__test__node_output@invalid_record.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@invalid_record.nu.snap
@@ -10,4 +10,10 @@ input_file: tests/invalid_record.nu
 4: Garbage (13 to 13)
 5: Record { pairs: [(NodeId(0), NodeId(1)), (NodeId(2), NodeId(4))] } (0 to 0)
 6: Block(BlockId(0)) (0 to 13)
+==== ERRORS ====
+Error (NodeId 3): expected: colon ':'
+Error (NodeId 4): incomplete expression
+==== SCOPE ====
+0: Frame Scope, variables: [  ], node_id: NodeId(6)
+1: Frame Scope, variables: [  ], node_id: NodeId(6)
 

--- a/src/snapshots/new_nu_parser__test__node_output@let_.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@let_.nu.snap
@@ -3,6 +3,7 @@ source: src/test.rs
 expression: evaluate_example(path)
 input_file: tests/let_.nu
 ---
+==== COMPILER ====
 0: Variable (4 to 5)
 1: Int (8 to 11)
 2: Let { variable_name: NodeId(0), ty: None, initializer: NodeId(1), is_mutable: false } (0 to 11)

--- a/src/snapshots/new_nu_parser__test__node_output@let_.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@let_.nu.snap
@@ -8,4 +8,7 @@ input_file: tests/let_.nu
 2: Let { variable_name: NodeId(0), ty: None, initializer: NodeId(1), is_mutable: false } (0 to 11)
 3: Variable (13 to 15)
 4: Block(BlockId(0)) (0 to 15)
+==== SCOPE ====
+0: Frame Scope, variables: [  ], node_id: NodeId(4)
+1: Frame Scope, variables: [ x: NodeId(0) ], node_id: NodeId(4)
 

--- a/src/snapshots/new_nu_parser__test__node_output@let_.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@let_.nu.snap
@@ -9,6 +9,5 @@ input_file: tests/let_.nu
 3: Variable (13 to 15)
 4: Block(BlockId(0)) (0 to 15)
 ==== SCOPE ====
-0: Frame Scope, variables: [  ], node_id: NodeId(4)
-1: Frame Scope, variables: [ x: NodeId(0) ], node_id: NodeId(4)
+0: Frame Scope, variables: [ x: NodeId(0) ], node_id: NodeId(4)
 

--- a/src/snapshots/new_nu_parser__test__node_output@list.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@list.nu.snap
@@ -3,6 +3,7 @@ source: src/test.rs
 expression: evaluate_example(path)
 input_file: tests/list.nu
 ---
+==== COMPILER ====
 0: Int (1 to 2)
 1: Int (4 to 5)
 2: Int (7 to 8)

--- a/src/snapshots/new_nu_parser__test__node_output@list.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@list.nu.snap
@@ -8,4 +8,7 @@ input_file: tests/list.nu
 2: Int (7 to 8)
 3: List([NodeId(0), NodeId(1), NodeId(2)]) (0 to 8)
 4: Block(BlockId(0)) (0 to 9)
+==== SCOPE ====
+0: Frame Scope, variables: [  ], node_id: NodeId(4)
+1: Frame Scope, variables: [  ], node_id: NodeId(4)
 

--- a/src/snapshots/new_nu_parser__test__node_output@list.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@list.nu.snap
@@ -10,5 +10,4 @@ input_file: tests/list.nu
 4: Block(BlockId(0)) (0 to 9)
 ==== SCOPE ====
 0: Frame Scope, variables: [  ], node_id: NodeId(4)
-1: Frame Scope, variables: [  ], node_id: NodeId(4)
 

--- a/src/snapshots/new_nu_parser__test__node_output@literals.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@literals.nu.snap
@@ -10,4 +10,7 @@ input_file: tests/literals.nu
 4: String (17 to 22)
 5: List([NodeId(0), NodeId(1), NodeId(2), NodeId(3), NodeId(4)]) (0 to 22)
 6: Block(BlockId(0)) (0 to 24)
+==== SCOPE ====
+0: Frame Scope, variables: [  ], node_id: NodeId(6)
+1: Frame Scope, variables: [  ], node_id: NodeId(6)
 

--- a/src/snapshots/new_nu_parser__test__node_output@literals.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@literals.nu.snap
@@ -3,6 +3,7 @@ source: src/test.rs
 expression: evaluate_example(path)
 input_file: tests/literals.nu
 ---
+==== COMPILER ====
 0: True (1 to 5)
 1: Null (6 to 10)
 2: Int (11 to 12)

--- a/src/snapshots/new_nu_parser__test__node_output@literals.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@literals.nu.snap
@@ -12,5 +12,4 @@ input_file: tests/literals.nu
 6: Block(BlockId(0)) (0 to 24)
 ==== SCOPE ====
 0: Frame Scope, variables: [  ], node_id: NodeId(6)
-1: Frame Scope, variables: [  ], node_id: NodeId(6)
 

--- a/src/snapshots/new_nu_parser__test__node_output@loop.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@loop.nu.snap
@@ -3,6 +3,7 @@ source: src/test.rs
 expression: evaluate_example(path)
 input_file: tests/loop.nu
 ---
+==== COMPILER ====
 0: Variable (4 to 5)
 1: Int (8 to 9)
 2: Let { variable_name: NodeId(0), ty: None, initializer: NodeId(1), is_mutable: true } (0 to 9)

--- a/src/snapshots/new_nu_parser__test__node_output@loop.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@loop.nu.snap
@@ -23,4 +23,6 @@ input_file: tests/loop.nu
 ==== SCOPE ====
 0: Frame Scope, variables: [  ], node_id: NodeId(16)
 1: Frame Scope, variables: [ x: NodeId(0) ], node_id: NodeId(16)
+2: Frame Scope, variables: [  ], node_id: NodeId(14)
+3: Frame Scope, variables: [  ], node_id: NodeId(8)
 

--- a/src/snapshots/new_nu_parser__test__node_output@loop.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@loop.nu.snap
@@ -20,4 +20,7 @@ input_file: tests/loop.nu
 14: Block(BlockId(1)) (15 to 68)
 15: Loop { block: NodeId(14) } (10 to 68)
 16: Block(BlockId(2)) (0 to 68)
+==== SCOPE ====
+0: Frame Scope, variables: [  ], node_id: NodeId(16)
+1: Frame Scope, variables: [ x: NodeId(0) ], node_id: NodeId(16)
 

--- a/src/snapshots/new_nu_parser__test__node_output@loop.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@loop.nu.snap
@@ -21,8 +21,7 @@ input_file: tests/loop.nu
 15: Loop { block: NodeId(14) } (10 to 68)
 16: Block(BlockId(2)) (0 to 68)
 ==== SCOPE ====
-0: Frame Scope, variables: [  ], node_id: NodeId(16)
-1: Frame Scope, variables: [ x: NodeId(0) ], node_id: NodeId(16)
-2: Frame Scope, variables: [  ], node_id: NodeId(14)
-3: Frame Scope, variables: [  ], node_id: NodeId(8)
+0: Frame Scope, variables: [ x: NodeId(0) ], node_id: NodeId(16)
+1: Frame Scope, variables: [  ], node_id: NodeId(14)
+2: Frame Scope, variables: [  ], node_id: NodeId(8)
 

--- a/src/snapshots/new_nu_parser__test__node_output@math.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@math.nu.snap
@@ -3,6 +3,7 @@ source: src/test.rs
 expression: evaluate_example(path)
 input_file: tests/math.nu
 ---
+==== COMPILER ====
 0: Int (0 to 1)
 1: Plus (2 to 3)
 2: Int (4 to 5)

--- a/src/snapshots/new_nu_parser__test__node_output@math.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@math.nu.snap
@@ -8,4 +8,7 @@ input_file: tests/math.nu
 2: Int (4 to 5)
 3: BinaryOp { lhs: NodeId(0), op: NodeId(1), rhs: NodeId(2) } (0 to 5)
 4: Block(BlockId(0)) (0 to 5)
+==== SCOPE ====
+0: Frame Scope, variables: [  ], node_id: NodeId(4)
+1: Frame Scope, variables: [  ], node_id: NodeId(4)
 

--- a/src/snapshots/new_nu_parser__test__node_output@math.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@math.nu.snap
@@ -10,5 +10,4 @@ input_file: tests/math.nu
 4: Block(BlockId(0)) (0 to 5)
 ==== SCOPE ====
 0: Frame Scope, variables: [  ], node_id: NodeId(4)
-1: Frame Scope, variables: [  ], node_id: NodeId(4)
 

--- a/src/snapshots/new_nu_parser__test__node_output@mut_.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@mut_.nu.snap
@@ -17,6 +17,5 @@ input_file: tests/mut_.nu
 11: BinaryOp { lhs: NodeId(5), op: NodeId(6), rhs: NodeId(10) } (18 to 30)
 12: Block(BlockId(0)) (0 to 30)
 ==== SCOPE ====
-0: Frame Scope, variables: [  ], node_id: NodeId(12)
-1: Frame Scope, variables: [ x: NodeId(0) ], node_id: NodeId(12)
+0: Frame Scope, variables: [ x: NodeId(0) ], node_id: NodeId(12)
 

--- a/src/snapshots/new_nu_parser__test__node_output@mut_.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@mut_.nu.snap
@@ -3,6 +3,7 @@ source: src/test.rs
 expression: evaluate_example(path)
 input_file: tests/mut_.nu
 ---
+==== COMPILER ====
 0: Variable (4 to 5)
 1: Name (7 to 10)
 2: Type { name: NodeId(1), params: None, optional: false } (7 to 10)

--- a/src/snapshots/new_nu_parser__test__node_output@mut_.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@mut_.nu.snap
@@ -16,4 +16,7 @@ input_file: tests/mut_.nu
 10: BinaryOp { lhs: NodeId(7), op: NodeId(8), rhs: NodeId(9) } (23 to 30)
 11: BinaryOp { lhs: NodeId(5), op: NodeId(6), rhs: NodeId(10) } (18 to 30)
 12: Block(BlockId(0)) (0 to 30)
+==== SCOPE ====
+0: Frame Scope, variables: [  ], node_id: NodeId(12)
+1: Frame Scope, variables: [ x: NodeId(0) ], node_id: NodeId(12)
 

--- a/src/snapshots/new_nu_parser__test__node_output@record.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@record.nu.snap
@@ -9,4 +9,7 @@ input_file: tests/record.nu
 3: Int (10 to 11)
 4: Record { pairs: [(NodeId(0), NodeId(1)), (NodeId(2), NodeId(3))] } (0 to 12)
 5: Block(BlockId(0)) (0 to 13)
+==== SCOPE ====
+0: Frame Scope, variables: [  ], node_id: NodeId(5)
+1: Frame Scope, variables: [  ], node_id: NodeId(5)
 

--- a/src/snapshots/new_nu_parser__test__node_output@record.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@record.nu.snap
@@ -11,5 +11,4 @@ input_file: tests/record.nu
 5: Block(BlockId(0)) (0 to 13)
 ==== SCOPE ====
 0: Frame Scope, variables: [  ], node_id: NodeId(5)
-1: Frame Scope, variables: [  ], node_id: NodeId(5)
 

--- a/src/snapshots/new_nu_parser__test__node_output@record.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@record.nu.snap
@@ -3,6 +3,7 @@ source: src/test.rs
 expression: evaluate_example(path)
 input_file: tests/record.nu
 ---
+==== COMPILER ====
 0: Name (1 to 2)
 1: Int (4 to 5)
 2: Name (7 to 8)

--- a/src/snapshots/new_nu_parser__test__node_output@record2.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@record2.nu.snap
@@ -3,6 +3,7 @@ source: src/test.rs
 expression: evaluate_example(path)
 input_file: tests/record2.nu
 ---
+==== COMPILER ====
 0: String (1 to 4)
 1: Int (6 to 7)
 2: String (9 to 12)

--- a/src/snapshots/new_nu_parser__test__node_output@record2.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@record2.nu.snap
@@ -9,4 +9,7 @@ input_file: tests/record2.nu
 3: Int (14 to 15)
 4: Record { pairs: [(NodeId(0), NodeId(1)), (NodeId(2), NodeId(3))] } (0 to 16)
 5: Block(BlockId(0)) (0 to 17)
+==== SCOPE ====
+0: Frame Scope, variables: [  ], node_id: NodeId(5)
+1: Frame Scope, variables: [  ], node_id: NodeId(5)
 

--- a/src/snapshots/new_nu_parser__test__node_output@record2.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@record2.nu.snap
@@ -11,5 +11,4 @@ input_file: tests/record2.nu
 5: Block(BlockId(0)) (0 to 17)
 ==== SCOPE ====
 0: Frame Scope, variables: [  ], node_id: NodeId(5)
-1: Frame Scope, variables: [  ], node_id: NodeId(5)
 

--- a/src/snapshots/new_nu_parser__test__node_output@record3.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@record3.nu.snap
@@ -11,5 +11,4 @@ input_file: tests/record3.nu
 5: Block(BlockId(0)) (0 to 17)
 ==== SCOPE ====
 0: Frame Scope, variables: [  ], node_id: NodeId(5)
-1: Frame Scope, variables: [  ], node_id: NodeId(5)
 

--- a/src/snapshots/new_nu_parser__test__node_output@record3.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@record3.nu.snap
@@ -3,6 +3,7 @@ source: src/test.rs
 expression: evaluate_example(path)
 input_file: tests/record3.nu
 ---
+==== COMPILER ====
 0: Name (2 to 3)
 1: Int (5 to 6)
 2: Name (9 to 10)

--- a/src/snapshots/new_nu_parser__test__node_output@record3.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@record3.nu.snap
@@ -9,4 +9,7 @@ input_file: tests/record3.nu
 3: Int (12 to 13)
 4: Record { pairs: [(NodeId(0), NodeId(1)), (NodeId(2), NodeId(3))] } (0 to 16)
 5: Block(BlockId(0)) (0 to 17)
+==== SCOPE ====
+0: Frame Scope, variables: [  ], node_id: NodeId(5)
+1: Frame Scope, variables: [  ], node_id: NodeId(5)
 

--- a/src/snapshots/new_nu_parser__test__node_output@reparse.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@reparse.nu.snap
@@ -16,4 +16,11 @@ input_file: tests/reparse.nu
 10: Name (33 to 36)
 11: Int (37 to 38)
 12: Block(BlockId(1)) (0 to 38)
+==== ERRORS ====
+Error (NodeId 3): expected list item
+Error (NodeId 7): variable not found
+==== SCOPE ====
+0: Frame Scope, variables: [  ], node_id: NodeId(12)
+1: Frame Scope, variables: [  ], node_id: NodeId(12)
+2: Frame Scope, variables: [  ], node_id: NodeId(8)
 

--- a/src/snapshots/new_nu_parser__test__node_output@reparse.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@reparse.nu.snap
@@ -3,6 +3,7 @@ source: src/test.rs
 expression: evaluate_example(path)
 input_file: tests/reparse.nu
 ---
+==== COMPILER ====
 0: Name (0 to 3)
 1: Name (4 to 7)
 2: Name (9 to 10)
@@ -16,10 +17,6 @@ input_file: tests/reparse.nu
 10: Name (33 to 36)
 11: Int (37 to 38)
 12: Block(BlockId(1)) (0 to 38)
-==== ERRORS ====
+==== COMPILER ERRORS ====
 Error (NodeId 3): expected list item
-Error (NodeId 7): variable not found
-==== SCOPE ====
-0: Frame Scope, variables: [  ], node_id: NodeId(12)
-1: Frame Scope, variables: [  ], node_id: NodeId(8)
 

--- a/src/snapshots/new_nu_parser__test__node_output@reparse.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@reparse.nu.snap
@@ -21,6 +21,5 @@ Error (NodeId 3): expected list item
 Error (NodeId 7): variable not found
 ==== SCOPE ====
 0: Frame Scope, variables: [  ], node_id: NodeId(12)
-1: Frame Scope, variables: [  ], node_id: NodeId(12)
-2: Frame Scope, variables: [  ], node_id: NodeId(8)
+1: Frame Scope, variables: [  ], node_id: NodeId(8)
 

--- a/src/snapshots/new_nu_parser__test__node_output@string.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@string.nu.snap
@@ -5,4 +5,7 @@ input_file: tests/string.nu
 ---
 0: String (0 to 13)
 1: Block(BlockId(0)) (0 to 13)
+==== SCOPE ====
+0: Frame Scope, variables: [  ], node_id: NodeId(1)
+1: Frame Scope, variables: [  ], node_id: NodeId(1)
 

--- a/src/snapshots/new_nu_parser__test__node_output@string.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@string.nu.snap
@@ -3,6 +3,7 @@ source: src/test.rs
 expression: evaluate_example(path)
 input_file: tests/string.nu
 ---
+==== COMPILER ====
 0: String (0 to 13)
 1: Block(BlockId(0)) (0 to 13)
 ==== SCOPE ====

--- a/src/snapshots/new_nu_parser__test__node_output@string.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@string.nu.snap
@@ -7,5 +7,4 @@ input_file: tests/string.nu
 1: Block(BlockId(0)) (0 to 13)
 ==== SCOPE ====
 0: Frame Scope, variables: [  ], node_id: NodeId(1)
-1: Frame Scope, variables: [  ], node_id: NodeId(1)
 

--- a/src/snapshots/new_nu_parser__test__node_output@string_operation.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@string_operation.nu.snap
@@ -10,5 +10,4 @@ input_file: tests/string_operation.nu
 4: Block(BlockId(0)) (0 to 13)
 ==== SCOPE ====
 0: Frame Scope, variables: [  ], node_id: NodeId(4)
-1: Frame Scope, variables: [  ], node_id: NodeId(4)
 

--- a/src/snapshots/new_nu_parser__test__node_output@string_operation.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@string_operation.nu.snap
@@ -8,4 +8,7 @@ input_file: tests/string_operation.nu
 2: String (8 to 13)
 3: BinaryOp { lhs: NodeId(0), op: NodeId(1), rhs: NodeId(2) } (0 to 13)
 4: Block(BlockId(0)) (0 to 13)
+==== SCOPE ====
+0: Frame Scope, variables: [  ], node_id: NodeId(4)
+1: Frame Scope, variables: [  ], node_id: NodeId(4)
 

--- a/src/snapshots/new_nu_parser__test__node_output@string_operation.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@string_operation.nu.snap
@@ -3,6 +3,7 @@ source: src/test.rs
 expression: evaluate_example(path)
 input_file: tests/string_operation.nu
 ---
+==== COMPILER ====
 0: String (0 to 5)
 1: Plus (6 to 7)
 2: String (8 to 13)

--- a/src/snapshots/new_nu_parser__test__node_output@table.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@table.nu.snap
@@ -3,6 +3,7 @@ source: src/test.rs
 expression: evaluate_example(path)
 input_file: tests/table.nu
 ---
+==== COMPILER ====
 0: String (7 to 10)
 1: String (12 to 15)
 2: List([NodeId(0), NodeId(1)]) (6 to 15)

--- a/src/snapshots/new_nu_parser__test__node_output@table.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@table.nu.snap
@@ -14,4 +14,7 @@ input_file: tests/table.nu
 8: List([NodeId(6), NodeId(7)]) (34 to 39)
 9: Table { header: NodeId(2), rows: [NodeId(5), NodeId(8)] } (0 to 41)
 10: Block(BlockId(0)) (0 to 42)
+==== SCOPE ====
+0: Frame Scope, variables: [  ], node_id: NodeId(10)
+1: Frame Scope, variables: [  ], node_id: NodeId(10)
 

--- a/src/snapshots/new_nu_parser__test__node_output@table.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@table.nu.snap
@@ -16,5 +16,4 @@ input_file: tests/table.nu
 10: Block(BlockId(0)) (0 to 42)
 ==== SCOPE ====
 0: Frame Scope, variables: [  ], node_id: NodeId(10)
-1: Frame Scope, variables: [  ], node_id: NodeId(10)
 

--- a/src/snapshots/new_nu_parser__test__node_output@table2.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@table2.nu.snap
@@ -14,4 +14,7 @@ input_file: tests/table2.nu
 8: List([NodeId(6), NodeId(7)]) (30 to 35)
 9: Table { header: NodeId(2), rows: [NodeId(5), NodeId(8)] } (0 to 37)
 10: Block(BlockId(0)) (0 to 38)
+==== SCOPE ====
+0: Frame Scope, variables: [  ], node_id: NodeId(10)
+1: Frame Scope, variables: [  ], node_id: NodeId(10)
 

--- a/src/snapshots/new_nu_parser__test__node_output@table2.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@table2.nu.snap
@@ -16,5 +16,4 @@ input_file: tests/table2.nu
 10: Block(BlockId(0)) (0 to 38)
 ==== SCOPE ====
 0: Frame Scope, variables: [  ], node_id: NodeId(10)
-1: Frame Scope, variables: [  ], node_id: NodeId(10)
 

--- a/src/snapshots/new_nu_parser__test__node_output@table2.nu.snap
+++ b/src/snapshots/new_nu_parser__test__node_output@table2.nu.snap
@@ -3,6 +3,7 @@ source: src/test.rs
 expression: evaluate_example(path)
 input_file: tests/table2.nu
 ---
+==== COMPILER ====
 0: Name (7 to 8)
 1: Name (10 to 11)
 2: List([NodeId(0), NodeId(1)]) (6 to 11)

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,7 +1,6 @@
 use crate::resolver::Resolver;
 use crate::{compiler::Compiler, parser::Parser};
 use std::path::Path;
-use std::process::exit;
 
 fn evaluate_example(fname: &Path) -> String {
     let mut compiler = Compiler::new();

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,5 +1,7 @@
+use crate::resolver::Resolver;
 use crate::{compiler::Compiler, parser::Parser};
 use std::path::Path;
+use std::process::exit;
 
 fn evaluate_example(fname: &Path) -> String {
     let mut compiler = Compiler::new();
@@ -9,11 +11,19 @@ fn evaluate_example(fname: &Path) -> String {
     compiler.add_file(&fname.to_string_lossy(), &contents);
 
     let parser = Parser::new(compiler, span_offset);
-
     compiler = parser.parse();
-    compiler.resolve();
 
-    compiler.display_state()
+    let mut result = compiler.display_state();
+
+    if !compiler.errors.is_empty() {
+        return result;
+    }
+
+    let mut resolver = Resolver::new(&compiler);
+    resolver.resolve();
+    result.push_str(&resolver.display_state());
+
+    result
 }
 
 #[test]

--- a/src/test.rs
+++ b/src/test.rs
@@ -11,6 +11,7 @@ fn evaluate_example(fname: &Path) -> String {
     let parser = Parser::new(compiler, span_offset);
 
     compiler = parser.parse();
+    compiler.resolve();
 
     compiler.display_state()
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -22,6 +22,8 @@ fn evaluate_example(fname: &Path) -> String {
     resolver.resolve();
     result.push_str(&resolver.display_state());
 
+    compiler.merge_name_bindings(resolver.to_name_bindings());
+
     result
 }
 

--- a/tests/closure.nu
+++ b/tests/closure.nu
@@ -1,1 +1,2 @@
 { |a, b| $a + $b}
+$a  # doesn't leak scope


### PR DESCRIPTION
Resolution pass performs binding of definition and use sites. Only implemented for variables in this PR. Includes:
* Scoping logic (entering and leaving blocks)
	* includes an idea how overlays could work, but overlays are not implemented yet
* Variable name resolution:
	* `let` and closure params define variables within scope
	* `$var` performs variable lookup within the current scope frame
* Added the scope information into the test report
* Added errors to the test report