### PR TITLE
Add pre-pass to tests to replace CRLF with LF, to fix tests on Windows

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -6,6 +6,13 @@ fn evaluate_example(fname: &Path) -> String {
     let mut compiler = Compiler::new();
     let contents = std::fs::read(fname).expect("We only run tests found by glob");
 
+    // Homogenize line endings from CRLF to LF to make sure tests work both on Windows and Linux/macOS
+    let contents = String::from_utf8(contents)
+        .unwrap()
+        .replace("\r\n", "\n")
+        .as_bytes()
+        .to_owned();
+
     let span_offset = compiler.span_offset();
     compiler.add_file(&fname.to_string_lossy(), &contents);
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -8,7 +8,7 @@ fn evaluate_example(fname: &Path) -> String {
 
     // Homogenize line endings from CRLF to LF to make sure tests work both on Windows and Linux/macOS
     let contents = String::from_utf8(contents)
-        .unwrap()
+        .expect("File is not valid utf-8")
         .replace("\r\n", "\n")
         .as_bytes()
         .to_owned();


### PR DESCRIPTION
This fixes running tests on Windows by replacing all CRLF line endings with LF before running tests.
Without this, running the tests on Windows results in different spans from the snapshots, failing the tests.

This _does not_ change the parsing though, where both CRLF and LF lines endings still need to be accounted for. (Although perhaps we could make this a global pre-parsing pass too?)